### PR TITLE
Add #cfp hashtag to tweet if a CFP is available

### DIFF
--- a/app/services/twitter/twitter_service.rb
+++ b/app/services/twitter/twitter_service.rb
@@ -44,6 +44,11 @@ module Twitter
       tweet << <<~PRBODY
         #tech #conference #{topics.map{ |topic| "##{topic.name}"}.join(" ")}
       PRBODY
+      if conference.cfpUrl.present? and conference.cfp_end_date.present?
+        tweet << <<~PRBODY
+          #cfp
+        PRBODY
+      end
       tweet.strip
     end
 


### PR DESCRIPTION
@nimzco I have no clue of Ruby. But I thought it might be nice include the hashtag #cfp if a cfp is available. Some people do that on twitter. I don't know if this code is correct. I don't know how to test it. I just copy/pasted code.