### PR TITLE
Support hybrid conferences

### DIFF
--- a/app/services/conferences/creation_service.rb
+++ b/app/services/conferences/creation_service.rb
@@ -34,6 +34,11 @@ class Conferences::CreationService < ApplicationService
       params[:online] = true
     end
 
+    if params[:online] == true && params[:city].blank? && params[:country].blank? 
+      params.delete(:country)
+      params.delete(:city)
+    end
+
     params[:url] = URLHelper.fix_url(params[:url].gsub(/\/$/, ''))
     params[:cfpUrl] = URLHelper.fix_url(params[:cfpUrl].gsub(/\/$/, '')) if params[:cfpUrl].present?
 

--- a/app/services/conferences/creation_service.rb
+++ b/app/services/conferences/creation_service.rb
@@ -34,11 +34,6 @@ class Conferences::CreationService < ApplicationService
       params[:online] = true
     end
 
-    if params[:online] == true
-      params.delete(:country)
-      params.delete(:city)
-    end
-
     params[:url] = URLHelper.fix_url(params[:url].gsub(/\/$/, ''))
     params[:cfpUrl] = URLHelper.fix_url(params[:cfpUrl].gsub(/\/$/, '')) if params[:cfpUrl].present?
 


### PR DESCRIPTION
@nimzco I think this lines prevent creating of hybrid conferences.
Are there any other scenarios where we need to delete ```country``` and ```city```?