### PR TITLE
Delete offersSignLanguageOrCC if false

### DIFF
--- a/app/services/conferences/creation_service.rb
+++ b/app/services/conferences/creation_service.rb
@@ -23,6 +23,7 @@ class Conferences::CreationService < ApplicationService
     params.delete(:cfpUrl) if params[:cfpUrl].blank?
     params.delete(:cfpEndDate) if params[:cfpEndDate].blank?
     params.delete(:cocUrl) if params[:cocUrl].blank?
+    params.delete(:offersSignLanguageOrCC) if params[:offersSignLanguageOrCC] == false
     params.delete(:twitter) if params[:twitter].blank? || params[:twitter] == '@'
 
     params[:name] = sanatize_name(params[:name])


### PR DESCRIPTION
@nimzco if ```offersSignLanguageOrCC``` is always set to ```false``` it makes merging multiple commits harder. I would prefer if it wouldn't be part of the json if the property is not true.

This code has not been tested. Will this work?