### PR TITLE
Update conference uuid to force reload if there is a change

### DIFF
--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -51,7 +51,8 @@ class Conference < ApplicationRecord
   end
 
   def get_uuid
-    Digest::SHA1.base64digest "#{URI.parse(url).host}-#{URI.parse(url).path}-#{startDate[0..6]}-#{city}"
+    uuid_attrs = [URI.parse(url).host, URI.parse(url).path, startDate[0..6], city, offersSignLanguageOrCC, online]
+    Digest::SHA1.base64digest uuid_attrs.join('-')
   end
 
   def set_uuid


### PR DESCRIPTION
I've updated the offersSignLanguageOrCC field of a conference and it wasn't updated because the conference UUID was the same.

This change will include this field in the conf uuid and will force reloading all conferences when they sync.