### PR TITLE
feat: add scraping functionality for conferences and update routes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -418,6 +418,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/app/controllers/api/conferences_controller.rb
+++ b/app/controllers/api/conferences_controller.rb
@@ -1,10 +1,23 @@
 require 'rss'
+require_relative '../../services/conference/scraper_service'
 
 class Api::ConferencesController < ApiController
   skip_before_action :authenticate_request
   before_action :validate_topics, only: :create
   before_action :validate_params, only: :create
 
+  def scrape
+    url = params[:url]
+    unless url.present?
+      render json: { error: 'URL missing' }, status: :bad_request and return
+    end
+    result = ConferenceScraper::ScraperService.scrape(url)
+    if result[:error]
+      render json: { error: result[:error] }, status: :unprocessable_entity
+    else
+      render json: result
+    end
+  end
   def index
     @conferences = Conference.first(limit)
     rss = RSS::Maker.make('2.0') do |maker|

--- a/app/services/conference/scraper_service.rb
+++ b/app/services/conference/scraper_service.rb
@@ -1,0 +1,24 @@
+require 'nokogiri'
+require 'open-uri'
+
+module ConferenceScraper
+  class ScraperService
+    def self.scrape(url)
+      begin
+        html = URI.open(url)
+        doc = Nokogiri::HTML(html)
+        # Simple extraction logic (customize selectors as needed)
+        title = doc.at('title')&.text || doc.at('h1')&.text
+        date = doc.at('[itemprop*="startDate"], .date, .event-date')&.text
+        location = doc.at('[itemprop*="location"], .location, .event-location')&.text
+        {
+          title: title&.strip,
+          date: date&.strip,
+          location: location&.strip
+        }
+      rescue => e
+        { error: e.message }
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
     resources :conferences, only: [:create, :index] do
       collection do
         get :cfp
+        post :scrape
       end
     end
     get '/webhooks/sync', to: 'webhooks#sync'


### PR DESCRIPTION
#110

This pull request introduces a new feature for scraping conference details from a provided URL. The changes include adding a new endpoint, implementing the scraping logic, and updating the routes to support the feature.

### API Enhancements:
* Added a new `scrape` action in `Api::ConferencesController` to handle requests for scraping conference details from a URL. The action validates the presence of the URL, calls the scraper service, and returns the result or an error message. (`app/controllers/api/conferences_controller.rb`, [app/controllers/api/conferences_controller.rbR2-R20](diffhunk://#diff-1477c338c3187fa7d0a350d3d9f3421d81f2cdf22dae0dca1593f7373e72a487R2-R20))

### Service Implementation:
* Introduced a `ScraperService` in the `ConferenceScraper` module that uses `Nokogiri` and `open-uri` to scrape conference details (title, date, location) from the provided URL. The service includes basic error handling and customizable selectors for extracting data. (`app/services/conference/scraper_service.rb`, [app/services/conference/scraper_service.rbR1-R24](diffhunk://#diff-265a2a2ec9eae3f02ad409b6f0f3968b53aea10d5e5ba3915f4eaf866bea31b4R1-R24))

### Route Updates:
* Added a new `POST /conferences/scrape` route to the `conferences` resource for invoking the scrape functionality. (`config/routes.rb`, [config/routes.rbR22](diffhunk://#diff-959bc9abc46a55332bb64d5155a79323afa75a50ec1a2137ddd22d926f62c6c5R22))